### PR TITLE
Fix string interpolation when caching canaries

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -29,7 +29,7 @@ async function install(version) {
   const newCachedPath = await tc.cacheDir(
     extractedFolder,
     "deno",
-    version.isCanary ? `0.0.0-${version}` : version.version,
+    version.isCanary ? `0.0.0-${version.version}` : version.version,
   );
   core.info(`Cached Deno to ${newCachedPath}.`);
   core.addPath(newCachedPath);


### PR DESCRIPTION
Previously, any canary's cache key would be `0.0.0-[object Object]` which isn't terribly ideal if multiple canaries are at play.

![Screenshot 2021-04-28 22 27 26](https://user-images.githubusercontent.com/40628/116468426-1f031a80-a871-11eb-9d23-a0ec43bca571.png)
