### PR TITLE
Add notice for Deno not following semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Set up your GitHub Actions workflow with a specific version of Deno.
 
 ### Latest stable
 
+> Note: we highly recommend specifying the latest stable version you want to test on because Deno does not follow semver and introduces non-backwards compatible changes within minor version bumps.
+
 ```yaml
 - uses: denoland/setup-deno@v1
   with:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Set up your GitHub Actions workflow with a specific version of Deno.
 
 ### Latest stable
 
-> Note: we highly recommend specifying the latest stable version you want to test on because Deno does not follow semver and introduces non-backwards compatible changes within minor version bumps.
+> Note: we highly recommend specifying the latest stable minor version you want to run on because Deno does not follow semver and introduces non-backwards compatible changes within minor version bumps.
 
 ```yaml
 - uses: denoland/setup-deno@v1


### PR DESCRIPTION
As shown by https://github.com/denoland/deno/issues/11340, highly impactive breaking changes will be introduced within minor versions of Deno.  It is best to warn people of this and have them specify their minor versions as well to stop all CI breaking again the next time a big breaking change like this is introduced again.