### PR TITLE
Run action on Node 16 instead Node 12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ outputs:
   is-canary:
     description: "If the installed Deno version was a canary version."
 runs:
-  using: "node12"
+  using: "node16"
   main: "main.js"


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/