### PR TITLE
feat: add deno-version-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Set up your GitHub Actions workflow with a specific version of Deno.
 
 ## Usage
 
+### Version from file
+
+```yaml
+- uses: denoland/setup-deno@v1
+  with:
+    deno-version-file: .dvmrc
+```
+
 ### Latest stable for a major
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,9 @@ branding:
   color: "gray-dark"
 inputs:
   deno-version:
-    description: The Deno version to install. Can be a semver version of a stable release, "canary" for the latest canary, or the Git hash of a specific canary release.
-    default: "1.x"
+    description: The Deno version to install. Can be a semver version of a stable release, "canary" for the latest canary, or the Git hash of a specific canary release. Defaults to "1.x".
+  deno-version-file:
+    description: File containing the Deno version to install. Overridden by deno-version.
 outputs:
   deno-version:
     description: "The Deno version that was installed."

--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const process = require("process");
 const core = require("@actions/core");
 
@@ -15,7 +16,11 @@ function exit(message) {
 
 async function main() {
   try {
-    const range = parseVersionRange(core.getInput("deno-version"));
+    const denoVersionFile = core.getInput("deno-version-file");
+    const range = parseVersionRange(
+      core.getInput("deno-version") ||
+        (denoVersionFile ? fs.readFileSync(denoVersionFile, "utf8") : "1.x"),
+    );
     if (range === null) {
       exit("The passed version range is not valid.");
     }


### PR DESCRIPTION
Like `actions/setup-node`, `deno-version` still takes precedence.

Fixes #32