### PR TITLE
add GitHub action to auto-update the semver major tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release new action version
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Tag name that the major tag will point to'
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+
+jobs:
+  update_tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/publish-action@v0.3.0
+        with:
+          source-tag: ${{ env.TAG_NAME }}


### PR DESCRIPTION
This will auto-update the v1 (or future majors) tag to the latest release using [actions/publish-action](https://github.com/actions/publish-action).

This makes it so that the very examples from the repo's README.md make use of the latest releases (i.e. one that doesn't have a deprecation warning). As of right now `@v1` resolution lags behind because it points to a branch https://github.com/denoland/setup-deno/tree/v1 which would propably best be deleted after this is merged (and manually ran to publish the tag without triggering a release).