### PR TITLE
Add problem matchers for `deno lint`

### DIFF
--- a/deno-problem-matchers.json
+++ b/deno-problem-matchers.json
@@ -1,0 +1,21 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "deno-lint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1B\\[[0-9;]*[a-zA-Z])*(warning|warn|error)(?:\\[(\\S*)\\])?(?:\\x1B\\[[0-9;]*[a-zA-Z])*: (.*?)(?:\\x1B\\[[0-9;]*[a-zA-Z])*$",
+          "severity": 1,
+          "code": 2,
+          "message": 3
+        },
+        {
+          "regexp": "^(?:\\s*)(?:\\x1B\\[[0-9;]*[a-zA-Z])*-->(?:\\x1B\\[[0-9;]*[a-zA-Z])* (?:\\x1B\\[[0-9;]*[a-zA-Z])*(\\S+?)(?:\\x1B\\[[0-9;]*[a-zA-Z])*:(\\d+):(\\d+)(?:\\x1B\\[[0-9;]*[a-zA-Z])*$",
+          "file": 1,
+          "line": 2,
+          "column": 3
+        }
+      ]
+    }
+  ]
+}

--- a/main.mjs
+++ b/main.mjs
@@ -1,5 +1,6 @@
 import process from "node:process";
 import core from "@actions/core";
+import path from "node:path";
 import {
   getDenoVersionFromFile,
   parseVersionRange,
@@ -37,6 +38,12 @@ async function main() {
     core.info(`Going to install ${version.kind} version ${version.version}.`);
 
     await install(version);
+
+    core.info(
+      `::add-matcher::${
+        path.join(import.meta.dirname ?? ".", "deno-problem-matchers.json")
+      }`,
+    );
 
     core.setOutput("deno-version", version.version);
     core.setOutput("release-channel", version.kind);


### PR DESCRIPTION
Related to:

- https://github.com/denoland/setup-deno/issues/53

I did not add a matcher for `deno fmt --check` this time, because I thought its output lacked tinformation to be used by problem matchers and could not be handled well.

I have tried this feature on my own sample project and confirmed that it works well like this:

![image](https://github.com/denoland/setup-deno/assets/111689/5c094451-25ee-4506-b655-5faa8f38f781)

The real example is here:

- https://github.com/r7kamura/bump-request/pull/12