### PR TITLE
feat: add "latest" as possible version

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -105,7 +105,11 @@ async function resolveVersion({ range, isCanary }) {
         "Failed to fetch release version info from dl.deno.land. Please try again later.",
       );
     }
-    const version = (await res.text()).trim();
+    let version = (await res.text()).trim();
+    version = semver.clean(version);
+    if (version === null) {
+      return null;
+    }
     return { version, isCanary: false };
   }
 

--- a/src/version.js
+++ b/src/version.js
@@ -30,6 +30,10 @@ function parseVersionRange(version) {
     return { range: "latest", isCanary: true };
   }
 
+  if (version == "latest") {
+    return { range: "latest", isCanary: false };
+  }
+
   if (GIT_HASH_RE.test(version)) {
     return { range: version, isCanary: true };
   }
@@ -90,6 +94,19 @@ async function resolveVersion({ range, isCanary }) {
       return { version, isCanary: true };
     }
     return { version: range, isCanary: true };
+  }
+
+  if (range === "latest") {
+    const res = await fetchWithRetries(
+      "https://dl.deno.land/release-latest.txt",
+    );
+    if (res.status !== 200) {
+      throw new Error(
+        "Failed to fetch release version info from dl.deno.land. Please try again later.",
+      );
+    }
+    const version = (await res.text()).trim();
+    return { version, isCanary: false };
   }
 
   const res = await fetchWithRetries("https://deno.com/versions.json");


### PR DESCRIPTION
To bypass a circular need of having the latest version during release, this bypasses dotcom's versions.json and instead uses https://dl.deno.land/release-latest.txt