### PR TITLE
2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setup-deno",
   "description": "Set up Deno easily in GitHub Actions",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": "Deno Land Inc",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Release 2.0.5.

Includes #130 ("chore: use versions.json from dl.deno.land"), which landed on `main` after the 2.0.4 tag.

Only change is the `package.json` version bump; `dist/` is already up to date on `main` (verified a fresh `deno task build` produces no diff).