### PR TITLE
fix: parse dvm's key=value format in .dvmrc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,25 @@ jobs:
       - name: Check version
         run: deno -V | grep -q "deno 1\.43\.1"
 
+  test-version-file-dvm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # dvm records the version as `key=value`, possibly not on the first line
+      - name: Write a dvm-style .dvmrc
+        run: |
+          printf 'registry_binary=https://dl.deno.land\ndeno_version=1.43.1\n' \
+            > "$RUNNER_TEMP/.dvmrc"
+
+      - name: Setup Deno
+        uses: ./
+        with:
+          deno-version-file: ${{ runner.temp }}/.dvmrc
+
+      - name: Check version
+        run: deno -V | grep -q "deno 1\.43\.1"
+
   test-binary-name:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -19331,7 +19331,8 @@ function getDenoVersionFromFile(versionFilePath) {
 	if (!fs$3.existsSync(versionFilePath)) throw new Error(`The specified node version file at: ${versionFilePath} does not exist`);
 	const contents = fs$3.readFileSync(versionFilePath, "utf8");
 	const denoVersionInToolVersions = contents.match(/^deno\s+v?(?<version>[^\s]+)$/m);
-	return denoVersionInToolVersions?.groups?.version || contents.trim();
+	const denoVersionInDvmrc = contents.match(/^[^\S\n]*deno_version[^\S\n]*=[^\S\n]*v?(?<version>[^\s]+)[^\S\n]*$/m);
+	return denoVersionInToolVersions?.groups?.version || denoVersionInDvmrc?.groups?.version || contents.trim();
 }
 function resolveVersion({ range, kind }) {
 	if (kind === "canary") return resolveCanary(range);

--- a/src/version.ts
+++ b/src/version.ts
@@ -75,7 +75,19 @@ export function getDenoVersionFromFile(
     /^deno\s+v?(?<version>[^\s]+)$/m,
   );
 
-  return denoVersionInToolVersions?.groups?.version || contents.trim();
+  // dvm writes .dvmrc as a `key=value` config rather than a bare version, and
+  // may record other keys before it:
+  // ```
+  // registry_binary=https://dl.deno.land
+  // deno_version=1.43.1
+  // ```
+  // This parses the version of Deno from the file
+  const denoVersionInDvmrc = contents.match(
+    /^[^\S\n]*deno_version[^\S\n]*=[^\S\n]*v?(?<version>[^\s]+)[^\S\n]*$/m,
+  );
+
+  return denoVersionInToolVersions?.groups?.version ||
+    denoVersionInDvmrc?.groups?.version || contents.trim();
 }
 
 export function resolveVersion(


### PR DESCRIPTION
The README documents that `deno-version-file` can read [dvm](https://github.com/justjavac/dvm)'s `.dvmrc`, but the parser only accepts a bare version string. dvm writes the file as `key=value` ([`configrc.rs`](https://github.com/justjavac/dvm/blob/main/src/configrc.rs) serializes with `format!("{}={}", k, v)`), so `deno_version=1.43.1` falls through to the bare-version branch and fails with `The passed version range is not valid.`

`.dvmrc` is a general key/value store rather than a single line, and dvm also records `registry_binary` / `registry_version`, so the version is not necessarily on the first line. The new pattern scans every line for the `deno_version` key. It runs only after the existing `.tool-versions` match, and the two patterns are disjoint, so bare-version and `.tool-versions` files behave exactly as before.

Also tolerates spaces around `=` (dvm's own reader trims both sides) and a `v` prefix, consistent with the existing `.tool-versions` handling.

Validation:
- `deno lint`, `deno fmt --check`, `deno check src/main.ts` all pass locally
- `deno run -A scripts/build.ts` rebuilt `dist/`, and a second build is byte-identical, so `build-diff` stays clean
- New `test-version-file-dvm` job writes a dvm-style `.dvmrc` with `deno_version` on the second line, so it covers the multi-key case rather than just a prefix strip
- Exercised the parser locally over 13 cases: dvm single-key / multi-key in both orders / spaces around `=` / `v` prefix / CRLF, plus regressions for bare version, bare range (`~1.32`), `.tool-versions`, and a `my_deno_versionx=` string that must not match

related: #121